### PR TITLE
Add gitmodule without shorthand

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "maryodel"]
 	path = maryodel
-	url = github:dmwit/maryodel
+	url = https://github.com/dmwit/maryodel


### PR DESCRIPTION
The short hand url does not play well with my primitive git.